### PR TITLE
Implementado DropDownMenu

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Kotlin2JsCompilerArguments">
+    <option name="moduleKind" value="plain" />
+  </component>
+  <component name="Kotlin2JvmCompilerArguments">
+    <option name="jvmTarget" value="1.8" />
+  </component>
+  <component name="KotlinCommonCompilerArguments">
+    <option name="apiVersion" value="2.1" />
+    <option name="languageVersion" value="2.1" />
+  </component>
+</project>

--- a/app/src/main/java/com/marcelo/loteriadossonhos/component/DropDownMenuCustom.kt
+++ b/app/src/main/java/com/marcelo/loteriadossonhos/component/DropDownMenuCustom.kt
@@ -1,0 +1,72 @@
+package com.marcelo.loteriadossonhos.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.tooling.preview.Preview
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AutoTextDropDown(initial: String, label: String, list: List<String>) {
+    var dropDownExpanded by remember { mutableStateOf(false) }
+    var textFieldValue by remember { mutableStateOf(TextFieldValue(initial)) }
+
+    ExposedDropdownMenuBox(
+        expanded = dropDownExpanded,
+        onExpandedChange = {
+            dropDownExpanded = !dropDownExpanded
+        }
+    ) {
+
+        OutlinedTextField(
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(),
+            value = textFieldValue,
+            onValueChange = {
+
+            },
+            readOnly = true,
+            label = {
+                Text(label)
+            },
+            trailingIcon = {
+                ExposedDropdownMenuDefaults.TrailingIcon(expanded = dropDownExpanded)
+            }
+        )
+
+        ExposedDropdownMenu(
+            expanded = dropDownExpanded,
+            onDismissRequest = { dropDownExpanded = false }
+        ) {
+            list.forEach { item ->
+                DropdownMenuItem(
+                    text = {
+                        Text(item)
+                    },
+                    onClick = {
+                        textFieldValue = TextFieldValue(item)
+                        dropDownExpanded = false
+                    })
+            }
+        }
+    }
+
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AutoTextDropDownPreview() {
+    AutoTextDropDown("", "", listOf())
+}

--- a/app/src/main/java/com/marcelo/loteriadossonhos/view/homeScreen/HomeScreenView.kt
+++ b/app/src/main/java/com/marcelo/loteriadossonhos/view/homeScreen/HomeScreenView.kt
@@ -5,16 +5,24 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.marcelo.loteriadossonhos.R
@@ -24,28 +32,62 @@ import com.marcelo.loteriadossonhos.ui.theme.Blue
 import com.marcelo.loteriadossonhos.ui.theme.Green
 import com.marcelo.loteriadossonhos.ui.theme.White
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(onClick: (MainItem) -> Unit) {
-    val mainItems = mutableListOf(
-        MainItem(1, "Mega Sena", Green, R.drawable.trevo),
-        MainItem(2, "Quina", Blue, R.drawable.trevo_blue)
-    )
 
     Surface(
         modifier = Modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.background
     ) {
-        LazyVerticalGrid(
-            verticalArrangement = Arrangement.SpaceAround,
-            columns = GridCells.Fixed(2)
-        ) {
-            items(mainItems) {
-                LotteryItem(it) {
-                    onClick(it)
-                }
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = {
+                        Text(
+                            text = "LOTOFÁCIL",
+                            color = White,
+                            fontWeight = FontWeight.Bold,
+                            fontFamily = FontFamily.Monospace
+                        )
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = Green
+                    )
+                )
             }
+        ) { paddingValues ->
 
+            HomeContentScreen(
+                modifier = Modifier.padding(
+                    top = paddingValues.calculateTopPadding()
+                )
+            ) {
+                onClick(it)
+            }
         }
+    }
+}
+
+@Composable
+fun HomeContentScreen(modifier: Modifier, onClick: (MainItem) -> Unit) {
+
+    val mainItems = mutableListOf(
+        MainItem(1, "Mega Sena", Green, R.drawable.trevo),
+        MainItem(2, "Quina", Blue, R.drawable.trevo_blue)
+    )
+
+    LazyVerticalGrid(
+        verticalArrangement = Arrangement.SpaceAround,
+        columns = GridCells.Fixed(2),
+        modifier = modifier.padding(top = 50.dp)
+    ) {
+        items(mainItems) {
+            LotteryItem(it) {
+                onClick(it)
+            }
+        }
+
     }
 }
 

--- a/app/src/main/java/com/marcelo/loteriadossonhos/view/megaSenaScreen/MegaSenaScreenView.kt
+++ b/app/src/main/java/com/marcelo/loteriadossonhos/view/megaSenaScreen/MegaSenaScreenView.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -36,6 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -44,6 +46,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.marcelo.loteriadossonhos.App
 import com.marcelo.loteriadossonhos.R
+import com.marcelo.loteriadossonhos.component.AutoTextDropDown
 import com.marcelo.loteriadossonhos.component.CustomTextField
 import com.marcelo.loteriadossonhos.component.LotteryHeaderItemTypeCustom
 import com.marcelo.loteriadossonhos.data.AppDatabase
@@ -129,6 +132,9 @@ fun MegaSenaContentScreen(modifier: Modifier = Modifier) {
     val coroutineScope = rememberCoroutineScope()
     val scrollState = rememberScrollState()
 
+    val rules = stringArrayResource(R.array.arrat_bet_rules)
+    var selectedItem by remember { mutableStateOf(rules.first()) }
+
     Column(
         verticalArrangement = Arrangement.spacedBy(20.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -167,6 +173,14 @@ fun MegaSenaContentScreen(modifier: Modifier = Modifier) {
             }
         }
 
+        Column(Modifier.width(280.dp)) {
+            AutoTextDropDown(
+                label = stringResource(R.string.bet_rules),
+                initial = selectedItem,
+                list = rules.toList()
+            )
+        }
+
         OutlinedButton(
             enabled = quantityBets.isNotEmpty() && quantityNumbers.isNotEmpty(),
             onClick = {
@@ -187,8 +201,9 @@ fun MegaSenaContentScreen(modifier: Modifier = Modifier) {
 
                 result = ""
                 resultsToSave.clear()
+                val rule = rules.indexOf(selectedItem)
                 for (index in 1..quantityBets.toInt()) {
-                    val numberGenerator = numberGenerator(quantityNumbers)
+                    val numberGenerator = numberGenerator(quantityNumbers, rule)
                     resultsToSave.add(numberGenerator)
 
                     result += "[ $index ] "
@@ -205,7 +220,7 @@ fun MegaSenaContentScreen(modifier: Modifier = Modifier) {
         Column(
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = modifier.padding(bottom = 20.dp)
+            modifier = Modifier.padding(bottom = 20.dp)
         ) {
             Text(result)
         }
@@ -259,12 +274,17 @@ fun MegaSenaContentScreen(modifier: Modifier = Modifier) {
     }
 }
 
-private fun numberGenerator(quantity: String): String {
+private fun numberGenerator(quantity: String, rule: Int): String {
     val numbers = mutableSetOf<Int>()
     while (true) {
         val numberRandom = Random().nextInt(60)
-        numbers.add(numberRandom + 1)
 
+        when (rule) {
+            1 -> if (numberRandom % 2 == 0) continue
+            2 -> if (numberRandom % 2 != 0) continue
+        }
+
+        numbers.add(numberRandom + 1)
         if (numbers.size == quantity.toInt()) break
     }
 

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="arrat_bet_rules">
+        <item>Padrão</item>
+        <item>Somente Pares</item>
+        <item>Somente Impares</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,4 +9,5 @@
     <string name="numero_quina">Numéro</string>
     <string name="save">Salvar</string>
     <string name="list_response"> [%3$s]\n[%1$d] [%2$s]\n%4$s </string>
+    <string name="bet_rules">Regras de apostas</string>
 </resources>


### PR DESCRIPTION
Esta Pull Request (PR) introduz um _DropdownMenu_ na tela _MegaSenaScreenView_ para permitir que o usuário selecione o tipo de aposta desejada entre:

> * Números Padrões: Aposta tradicional com seleção livre de números.
> * Pares: Aposta contendo apenas números pares.
> * Ímpares: Aposta contendo apenas números ímpares.

Esta funcionalidade visa oferecer mais opções e flexibilidade ao usuário na hora de realizar suas apostas na Mega Sena. A implementação segue o padrão visual e de componentes já estabelecido no projeto, como o uso do _TopAppBar_ na _HomeScreenView_.

Detalhes da Implementação:

1. Modificações em _MegaSenaScreenView.kt_:
2. Adição do Estado para o _Dropdown_.
3. Criação do _DropdownMenu_.
4. Atualização da Lógica de Geração/Seleção de Números:

> * A lógica existente para gerar ou permitir a seleção de números foi modificada para considerar o selectedBetType.•Por exemplo, se "Pares" estiver selecionado, apenas números pares devem ser considerados ou permitidos para seleção.

Interface do Usuário (UI):
> * O _DropdownMenu_ foi estilizado para manter a consistência visual com o restante do aplicativo, utilizando cores e fontes definidas no tema (_MaterialTheme_).

## Screenshot:
<img width="320" alt="image" src="https://github.com/user-attachments/assets/fc9d959c-1e79-4c47-bfe0-05957be57af5" />
<img width="320" alt="image" src="https://github.com/user-attachments/assets/fb239222-09ab-4b4c-8f11-7d748b8f2e23" />
<img width="320" alt="image" src="https://github.com/user-attachments/assets/327a1e78-450a-462b-b68e-14c34716afba" />



