### PR TITLE
Refactor: Implementação da arquitetura MVVM com Repository e Coroutines

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,11 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-08-13T16:44:12.809672079Z">
+        <DropdownSelection timestamp="2025-08-21T18:36:53.165856086Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/home/tchelo/.android/avd/Pixel_9.avd" />
+              <DeviceId pluginId="FirebaseDirectAccess" identifier="reservation=projects/device-streaming-d3ff3af1/deviceSessions/session-3jf0l1mx5fkv3" />
             </handle>
+            <template>
+              <DeviceId pluginId="FirebaseDirectAccess" type="TEMPLATE" identifier="model_id=redfin/30" />
+            </template>
           </Target>
         </DropdownSelection>
         <DialogSelection />

--- a/.idea/deviceManager.xml
+++ b/.idea/deviceManager.xml
@@ -5,6 +5,10 @@
       <list>
         <ColumnSorterState>
           <option name="column" value="Name" />
+          <option name="order" value="DESCENDING" />
+        </ColumnSorterState>
+        <ColumnSorterState>
+          <option name="column" value="API" />
           <option name="order" value="ASCENDING" />
         </ColumnSorterState>
       </list>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -7,7 +7,7 @@
     <option name="jvmTarget" value="1.8" />
   </component>
   <component name="KotlinCommonCompilerArguments">
-    <option name="apiVersion" value="2.1" />
-    <option name="languageVersion" value="2.1" />
+    <option name="apiVersion" value="2.0" />
+    <option name="languageVersion" value="2.0" />
   </component>
 </project>

--- a/.idea/project.prompts.xml
+++ b/.idea/project.prompts.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PromptTemplates">
+    <option name="prompts">
+      <list>
+        <PromptTemplate>
+          <option name="enabled" value="true" />
+          <option name="name" value="Como contornar esse erro do preview de BetListDetailScreen?" />
+          <option name="text" value="Como contornar esse erro do preview de BetListDetailScreen?" />
+        </PromptTemplate>
+      </list>
+    </option>
+  </component>
+</project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
-    id("com.google.devtools.ksp")
+    alias(libs.plugins.devtools.ksp)
 }
 
 android {
@@ -50,13 +50,11 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
-    val nav_version = "2.9.0"
-    implementation("androidx.navigation:navigation-compose:$nav_version")
 
-    val room_version = "2.7.2"
-    implementation("androidx.room:room-runtime:${room_version}")
-    ksp("androidx.room:room-compiler:${room_version}")
-    implementation("androidx.room:room-ktx:${room_version}")
+    implementation(libs.androidx.navigation)
+    implementation(libs.androidx.room)
+    ksp(libs.androidx.room.compiler)
+    implementation(libs.androidx.room.ktx)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/marcelo/loteriadossonhos/data/BetDao.kt
+++ b/app/src/main/java/com/marcelo/loteriadossonhos/data/BetDao.kt
@@ -8,8 +8,8 @@ import androidx.room.Query
 interface BetDao {
 
     @Insert
-    fun insert(bet: Bet)
+    suspend fun insert(bet: Bet)
 
     @Query("SELECT * FROM bet WHERE tipo = :betType")
-    fun getNumbersByType(betType: String): List<Bet>
+    suspend fun getNumbersByType(betType: String): List<Bet>
 }

--- a/app/src/main/java/com/marcelo/loteriadossonhos/data/BetRepository.kt
+++ b/app/src/main/java/com/marcelo/loteriadossonhos/data/BetRepository.kt
@@ -1,0 +1,32 @@
+package com.marcelo.loteriadossonhos.data
+
+class BetRepository(private val betDao: BetDao) {
+
+    suspend fun getBets(type: String): List<Bet> {
+        // Formas de buscar os dados.
+        return betDao.getNumbersByType(type)
+    }
+
+    suspend fun insertBet(bet: Bet) {
+        return betDao.insert(bet)
+    }
+
+    companion object {
+        private var instance: BetRepository? = null
+
+        fun getInstance(betDao: BetDao): BetRepository {
+            instance = when {
+
+                instance != null -> {
+                    instance!!
+                }
+
+                else -> {
+                    BetRepository(betDao)
+                }
+            }
+
+            return instance!!
+        }
+    }
+}

--- a/app/src/main/java/com/marcelo/loteriadossonhos/nav/AppNavHost.kt
+++ b/app/src/main/java/com/marcelo/loteriadossonhos/nav/AppNavHost.kt
@@ -8,7 +8,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.marcelo.loteriadossonhos.routes.AppRouter
-import com.marcelo.loteriadossonhos.view.betDetailScreen.BetDatailScreen
+import com.marcelo.loteriadossonhos.view.betListDetailScreen.BetListDatailContent
 import com.marcelo.loteriadossonhos.view.homeScreen.HomeScreen
 import com.marcelo.loteriadossonhos.view.megaSenaScreen.MegaSenaScreen
 import com.marcelo.loteriadossonhos.view.quinaScreen.QuinaScreen
@@ -61,10 +61,11 @@ fun AppNavHost(modifier: Modifier = Modifier) {
                     type = NavType.StringType
                 })
         ) {
-            val type = it.arguments?.getString("type") ?: throw Exception("Tipo não encontrado")
-            BetDatailScreen(
+            val type = it.arguments?.getString("type") ?: throw Exception("Erro, type not found!")
+            BetListDatailContent(
                 type = type,
-                onBackClick = {navController.popBackStack()})
+                onBackClick = {navController.popBackStack()}
+            )
         }
     }
 }

--- a/app/src/main/java/com/marcelo/loteriadossonhos/view/betListDetailScreen/BetListDetailScreen.kt
+++ b/app/src/main/java/com/marcelo/loteriadossonhos/view/betListDetailScreen/BetListDetailScreen.kt
@@ -1,4 +1,4 @@
-package com.marcelo.loteriadossonhos.view.betDetailScreen
+package com.marcelo.loteriadossonhos.view.betListDetailScreen
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -16,25 +16,28 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.marcelo.loteriadossonhos.App
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.marcelo.loteriadossonhos.R
-import com.marcelo.loteriadossonhos.data.AppDatabase
 import com.marcelo.loteriadossonhos.data.Bet
 import com.marcelo.loteriadossonhos.ui.theme.Gray
 import com.marcelo.loteriadossonhos.ui.theme.White
+import com.marcelo.loteriadossonhos.viewModels.BetListDetailViewModel
 import java.text.SimpleDateFormat
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun BetDatailScreen(type: String, onBackClick: () -> Unit) {
+fun BetListDatailScreen(
+    type: String,
+    bets: List<Bet> = emptyList(),
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Surface(
         modifier = Modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.background
@@ -63,57 +66,51 @@ fun BetDatailScreen(type: String, onBackClick: () -> Unit) {
                 )
             }
         ) { paddingValues ->
-            BetDatailContentScreen(
-                modifier = Modifier.padding(
+
+            val simpleDateFormat = SimpleDateFormat("dd/MM/yyyy HH:mm:ss", Locale("pt", "BR"))
+
+            LazyColumn(
+                modifier.padding(
                     top = paddingValues.calculateTopPadding(),
                     bottom = paddingValues.calculateBottomPadding()
-                ),
-                type = type
-            )
+                )
+            ) {
+                itemsIndexed(bets) { index, bet ->
+                    Text(
+                        stringResource(
+                            id = R.string.list_response,
+                            index,
+                            simpleDateFormat.format(bet.date),
+                            bet.type,
+                            bet.numbers
+                        ),
+                        Modifier.padding(vertical = 10.dp, horizontal = 10.dp)
+                    )
+                }
+            }
         }
     }
 }
 
 @Composable
-fun BetDatailContentScreen(type: String, modifier: Modifier = Modifier) {
+fun BetListDatailContent(
+    type: String,
+    onBackClick: () -> Unit,
+    betViewModel: BetListDetailViewModel = viewModel(factory = BetListDetailViewModel.factory),
+) {
 
-    // Realiza a verificação se está renderizando no Preview
-    val isInPreview = LocalInspectionMode.current
-    val database: AppDatabase? = if (!isInPreview) {
-        // Referencia do context da class App
-        (LocalContext.current.applicationContext as App).appDatabse
-    } else {
-        null
-    }
+    val bets = betViewModel.bet.collectAsState(initial = emptyList()).value
 
-    val bets = remember { mutableStateListOf<Bet>() }
-    val simpleDateFormat = SimpleDateFormat("dd/MM/yyyy HH:mm:ss", java.util.Locale("pt", "BR"))
+    BetListDatailScreen(
+        type = type,
+        bets = bets,
+        onBackClick = onBackClick
+    )
 
-    Thread {
-        val listBets = database?.betDao()?.getNumbersByType(type)
-        bets.clear()
-        listBets?.let { bets.addAll(it) }
-    }.start()
-
-
-    LazyColumn(modifier) {
-        itemsIndexed(bets) { index, bet ->
-            Text(
-                stringResource(
-                    id = R.string.list_response,
-                    index,
-                    simpleDateFormat.format(bet.date),
-                    bet.type,
-                    bet.numbers
-                ),
-                Modifier.padding(vertical = 10.dp, horizontal = 10.dp)
-            )
-        }
-    }
 }
 
 @Preview(showBackground = true)
 @Composable
 private fun BetDatailsScreenPreview() {
-    BetDatailScreen(type = "megasena", onBackClick = {})
+    BetListDatailScreen(type = "megasena", onBackClick = {})
 }

--- a/app/src/main/java/com/marcelo/loteriadossonhos/view/megaSenaScreen/MegaSenaScreenView.kt
+++ b/app/src/main/java/com/marcelo/loteriadossonhos/view/megaSenaScreen/MegaSenaScreenView.kt
@@ -61,6 +61,7 @@ import java.util.Random
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MegaSenaScreen(onMenuClick: (String) -> Unit, onBackClick: () -> Unit) {
+    val snackbarHostState by remember { mutableStateOf(SnackbarHostState()) }
 
     Surface(
         modifier = Modifier.fillMaxSize(),
@@ -102,14 +103,23 @@ fun MegaSenaScreen(onMenuClick: (String) -> Unit, onBackClick: () -> Unit) {
                     }
                 )
             },
+            snackbarHost = {
+                SnackbarHost(hostState = snackbarHostState)
+            }
         ) { paddingValues ->
-            MegaSenaContentScreen(modifier = Modifier.padding(top = paddingValues.calculateTopPadding()))
+            MegaSenaContentScreen(
+                modifier = Modifier.padding(top = paddingValues.calculateTopPadding()),
+                snackbarHostState
+            )
         }
     }
 }
 
 @Composable
-fun MegaSenaContentScreen(modifier: Modifier = Modifier) {
+fun MegaSenaContentScreen(
+    modifier: Modifier = Modifier,
+    snackbarHostState: SnackbarHostState,
+) {
 
     val isInPreview = LocalInspectionMode.current
     // Referencia do context da class App
@@ -128,7 +138,6 @@ fun MegaSenaContentScreen(modifier: Modifier = Modifier) {
     // Armazenar as apostas para o DB
     val resultsToSave = remember { mutableStateListOf<String>() }
 
-    val snackbarHostState by remember { mutableStateOf(SnackbarHostState()) }
     val coroutineScope = rememberCoroutineScope()
     val scrollState = rememberScrollState()
 

--- a/app/src/main/java/com/marcelo/loteriadossonhos/viewModels/BetListDetailViewModel.kt
+++ b/app/src/main/java/com/marcelo/loteriadossonhos/viewModels/BetListDetailViewModel.kt
@@ -1,0 +1,48 @@
+package com.marcelo.loteriadossonhos.viewModels
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
+import com.marcelo.loteriadossonhos.App
+import com.marcelo.loteriadossonhos.data.Bet
+import com.marcelo.loteriadossonhos.data.BetRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class BetListDetailViewModel(
+    private val savedStateHandle: SavedStateHandle,
+    private val betRepository: BetRepository
+) : ViewModel() {
+
+    private val _bet = MutableStateFlow<List<Bet>>(emptyList())
+    val bet: StateFlow<List<Bet>> = _bet.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            val type = savedStateHandle.get<String>("type") ?: throw Exception("Erro, tipy not found!")
+            val bets = betRepository.getBets(type)
+            _bet.value = bets
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    companion object {
+        val factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+
+                val application = extras[APPLICATION_KEY]
+                val betDao = (application as App).appDatabse.betDao()
+                val repository = BetRepository.getInstance(betDao = betDao)
+
+                val savedStateHandle = extras.createSavedStateHandle()
+                return BetListDetailViewModel(savedStateHandle, repository) as T
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,8 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.9.0"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
+nav-version = "2.9.0"
+room-version = "2.7.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -25,8 +27,14 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 
+androidx-navigation = {group = "androidx.navigation", name = "navigation-compose", version.ref = "nav-version"}
+androidx-room = {group = "androidx.room", name = "room-runtime", version.ref = "room-version"}
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room-version" }
+androidx-room-ktx = {group = "androidx.room", name = "room-ktx", version.ref = "room-version"}
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+devtools-ksp = {id = "com.google.devtools.ksp"}
 


### PR DESCRIPTION
Esta Pull Request refatora a funcionalidade de listagem de apostas salvas (BetListDetailScreen) para seguir os princípios modernos da arquitetura Android, utilizando um padrão MVVM (Model-View-ViewModel) completo. A mudança principal move toda a lógica de acesso a dados da camada de UI para ViewModels e Repositórios, garantindo a separação de responsabilidades e melhorando a manutenibilidade, testabilidade e robustez do código.

**Resumo das Mudanças**

O objetivo principal foi resolver problemas de arquitetura, como o acesso direto ao banco de dados a partir da UI, e evitar o erro IllegalStateException ao realizar operações de banco de dados na thread principal.

**O que foi feito:**

**1. Introdução do BetListDetailViewModel:**

- Uma nova classe BetListDetailViewModel foi criada para gerenciar o estado da UI (BetListDetailScreen).
- Ela é responsável por solicitar os dados ao BetRepository e expor a lista de apostas para a UI através de um StateFlow, garantindo que a UI seja reativa às mudanças nos dados.
- Toda a lógica de busca de dados foi movida para dentro de um viewModelScope.launch, garantindo que as chamadas ao banco de dados (que são suspend fun) rodem em uma background thread, sem bloquear a UI.

**2. Criação do BetRepository:**

- Implementado o Repository Pattern através da classe BetRepository.
- Este repositório agora atua como a única fonte da verdade (Single Source of Truth) para os dados de apostas. Ele abstrai a origem dos dados (atualmente, o Room Database) do resto do aplicativo.
- Qualquer ViewModel que precise de dados de apostas agora se comunicará com o BetRepository, em vez de interagir diretamente com o DAO. Isso centraliza a lógica de dados e facilita futuras mudanças (ex: adicionar uma fonte de dados remota).

**3. Uso de ViewModelProvider.Factory:**

- Como o BetListDetailViewModel agora depende de um BetRepository em seu construtor, foi criada uma ViewModelProvider.Factory personalizada.
- A factory ensina ao sistema Android como instanciar o BetListDetailViewModel, fornecendo a ele a instância necessária do BetRepository. Isso é crucial para a injeção de dependências manual.
- 

**4. Atualização da Camada de Dados (Room DAO):**

- As funções no BetDao que realizam leituras do banco de dados (como getBetsByType) foram confirmadas como suspend fun. Isso força que elas sejam chamadas a partir de uma Coroutine, garantindo a segurança da thread.

**5. Refatoração da UI (BetListDetailScreen):**

- O Composable BetListDetailScreen foi significativamente simplificado.
- Ele não contém mais nenhuma lógica de busca de dados. Sua única responsabilidade agora é observar o StateFlow exposto pelo BetListDetailViewModel (usando collectAsState()) e renderizar a lista de apostas recebida.